### PR TITLE
Fix/action prank behavior

### DIFF
--- a/test/SpotlightIPCollection.t.sol
+++ b/test/SpotlightIPCollection.t.sol
@@ -63,9 +63,10 @@ contract SpotlightIPCollectionTest is Test {
     function test_notOwnerMintTo() public {
         address notOwner = makeAddr("notOwner");
         address receiver = makeAddr("receiver");
+        _enableMint();
         vm.expectRevert();
         vm.prank(notOwner);
-        _mintTo(receiver);
+        _spotlightIPCollection.mint(receiver);
     }
 
     function test_mintToBeforeEnabled() public {


### PR DESCRIPTION
the error because:  overwrite a prank until it is applied at least once

```
function test_notOwnerMintTo() public {
        address notOwner = makeAddr("notOwner");
        address receiver = makeAddr("receiver");
->        vm.startPrank(notOwner);
        vm.expectRevert();
        _mintTo(receiver);
        vm.stopPrank();
    }
````

```
 function _mintTo(address _receiver) private returns (uint256) {
        _enableMint();
->        vm.startPrank(_ownerAddr);
        uint256 tokenId = _spotlightIPCollection.mint(_receiver);
        vm.stopPrank();
        return tokenId;
    }
```    

